### PR TITLE
Make logging optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ public class App extends Application {
                 .withBeaconKey("YOUR_BEACON_KEY")
                 // Uncomment to disallow location collection
                 // .withDisallowLocationCollection(true)
+                // Uncomment to enable debug logging for development and testing
+                // .withDebugLoggingEnabled(true)
                 .build());
             Sift.collect();
         }
@@ -123,6 +125,8 @@ public class MainActivity extends AppCompatActivity {
             .withBeaconKey("YOUR_BEACON_KEY")
             // Uncomment to disallow location collection
             // .withDisallowLocationCollection(true)
+            // Uncomment to enable debug logging for development and testing
+            // .withDebugLoggingEnabled(true)
             .build());
         Sift.collect();
     }

--- a/hello-sift/src/main/java/siftscience/android/hellosift/HelloSiftTest.java
+++ b/hello-sift/src/main/java/siftscience/android/hellosift/HelloSiftTest.java
@@ -31,6 +31,7 @@ public class HelloSiftTest extends AppCompatActivity {
                 .withAccountId("bar")
                 .withBeaconKey("baz")
                 .withDisallowLocationCollection(true)
+                .withEnableDebugLogging(true)
                 .build());
 
         Sift.get().setUserId("foo");

--- a/hello-sift/src/main/java/siftscience/android/hellosift/HelloSiftTest.java
+++ b/hello-sift/src/main/java/siftscience/android/hellosift/HelloSiftTest.java
@@ -31,7 +31,7 @@ public class HelloSiftTest extends AppCompatActivity {
                 .withAccountId("bar")
                 .withBeaconKey("baz")
                 .withDisallowLocationCollection(true)
-                .withEnableDebugLogging(true)
+                .withDebugLoggingEnabled(true)
                 .build());
 
         Sift.get().setUserId("foo");

--- a/sift/src/main/java/siftscience/android/AppStateCollector.java
+++ b/sift/src/main/java/siftscience/android/AppStateCollector.java
@@ -73,7 +73,7 @@ public class AppStateCollector implements LocationListener,
                         .build();
                 this.googleApiClient.connect();
             } catch (Exception e) {
-                Log.e(TAG, e.toString());
+                if (sift.getConfig().enableDebugLogging)Log.e(TAG, e.toString());
             }
         } else {
             // Collect without location if disallowed on Sift config
@@ -93,7 +93,7 @@ public class AppStateCollector implements LocationListener,
     }
 
     public void disconnectLocationServices() {
-        Log.d(TAG, "Disconnect location services");
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Disconnect location services");
 
         try {
             if (!this.sift.getConfig().disallowLocationCollection &&
@@ -101,19 +101,19 @@ public class AppStateCollector implements LocationListener,
                 this.googleApiClient.disconnect();
             }
         } catch (Exception e) {
-            Log.e(TAG, e.toString());
+            if (sift.getConfig().enableDebugLogging)Log.e(TAG, e.toString());
         }
     }
 
     public void reconnectLocationServices() {
-        Log.d(TAG, "Reconnect location services");
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Reconnect location services");
 
         try {
             if (!this.sift.getConfig().disallowLocationCollection) {
                 this.googleApiClient.connect();
             }
         } catch (Exception e) {
-            Log.e(TAG, e.toString());
+            if (sift.getConfig().enableDebugLogging)Log.e(TAG, e.toString());
         }
     }
 
@@ -172,7 +172,7 @@ public class AppStateCollector implements LocationListener,
                 }
             }
         } catch (SocketException e) {
-            Log.e(TAG, e.toString());
+            if (sift.getConfig().enableDebugLogging)Log.e(TAG, e.toString());
         }
         return addresses;
     }
@@ -182,7 +182,7 @@ public class AppStateCollector implements LocationListener,
     }
 
     private AndroidDeviceLocationJson getLocation() {
-        Log.d(TAG, "Using " + (this.acquiredNewLocation ?
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Using " + (this.acquiredNewLocation ?
                 "new location" : "last location"));
 
         Location location = this.acquiredNewLocation ? this.location : this.lastLocation;
@@ -196,7 +196,7 @@ public class AppStateCollector implements LocationListener,
     }
 
     private void requestLocation() {
-        Log.d(TAG, "Requested location");
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Requested location");
 
         this.locationRequest = LocationRequest.create()
                 .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)
@@ -215,7 +215,7 @@ public class AppStateCollector implements LocationListener,
 
     @Override
     public void onLocationChanged(Location location) {
-        Log.d(TAG, "Location changed");
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Location changed");
 
         this.acquiredNewLocation = true;
         this.location = location;
@@ -227,13 +227,13 @@ public class AppStateCollector implements LocationListener,
                         .removeLocationUpdates(this.googleApiClient, this);
             }
         } catch (Exception e) {
-            Log.e(TAG, "Encountered Exception in onLocationChanged", e);
+            if (sift.getConfig().enableDebugLogging)Log.e(TAG, "Encountered Exception in onLocationChanged", e);
         }
     }
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
-        Log.d(TAG, "Connected to Google API Client");
+        if (sift.getConfig().enableDebugLogging)Log.d(TAG, "Connected to Google API Client");
 
         if (ContextCompat.checkSelfPermission(this.context,
                 Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED &&

--- a/sift/src/main/java/siftscience/android/DevicePropertiesCollector.java
+++ b/sift/src/main/java/siftscience/android/DevicePropertiesCollector.java
@@ -113,7 +113,7 @@ public class DevicePropertiesCollector {
             appVersion = packageManager.getPackageInfo(this.context.getPackageName(), 0)
                     .versionName;
         } catch (final PackageManager.NameNotFoundException e) {
-            Log.e(TAG, "Encountered NameNotFoundException in get", e);
+            if (sift.getConfig().enableDebugLogging) Log.e(TAG, "Encountered NameNotFoundException in get", e);
         }
 
         // Telephony properties
@@ -234,7 +234,7 @@ public class DevicePropertiesCollector {
             String[] args = line.split(" ");
             if (args.length < 4){
                 // If we don't have enough options per line, skip this and log an error
-                Log.e(TAG, String.format("Error formatting mount: %s", line));
+                if (sift.getConfig().enableDebugLogging) Log.e(TAG, String.format("Error formatting mount: %s", line));
                 continue;
             }
             String mountPoint = args[1];
@@ -264,7 +264,7 @@ public class DevicePropertiesCollector {
         try {
             inputstream = Runtime.getRuntime().exec("getprop").getInputStream();
         } catch (IOException e) {
-            Log.e(TAG, "Error reading properties", e);
+            if (sift.getConfig().enableDebugLogging) Log.e(TAG, "Error reading properties", e);
         }
         if (inputstream == null) {
             return ArrayUtils.EMPTY_STRING_ARRAY;
@@ -274,7 +274,7 @@ public class DevicePropertiesCollector {
         try {
             allProperties = new Scanner(inputstream).useDelimiter("\\A").next();
         } catch (NoSuchElementException e) {
-            Log.e(TAG, "Error reading properties", e);
+            if (sift.getConfig().enableDebugLogging) Log.e(TAG, "Error reading properties", e);
         }
         return allProperties.split("\n");
     }
@@ -288,7 +288,7 @@ public class DevicePropertiesCollector {
         try {
             inputstream = Runtime.getRuntime().exec("mount").getInputStream();
         } catch (IOException e) {
-            Log.e(TAG, "Error reading mount", e);
+            if (sift.getConfig().enableDebugLogging) Log.e(TAG, "Error reading mount", e);
         }
         if (inputstream == null) {
             return ArrayUtils.EMPTY_STRING_ARRAY;
@@ -298,7 +298,7 @@ public class DevicePropertiesCollector {
         try {
             allPaths = new Scanner(inputstream).useDelimiter("\\A").next();
         } catch (NoSuchElementException e) {
-            Log.e(TAG, "Error reading mount", e);
+            if (sift.getConfig().enableDebugLogging) Log.e(TAG, "Error reading mount", e);
         }
         return allPaths.split("\n");
     }

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -210,7 +210,7 @@ public class Sift {
             }
 
             private boolean enableDebugLogging;
-            public Builder withEnableDebugLogging(boolean enableDebugLogging) {
+            public Builder withDebugLoggingEnabled(boolean enableDebugLogging) {
                 this.enableDebugLogging = enableDebugLogging;
                 return this;
             }

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -59,7 +59,7 @@ public class Sift {
                 appStateCollector = new AppStateCollector(instance, c,
                         context.getClass().getSimpleName());
             } catch (IOException e) {
-                Log.e(TAG, "Encountered IOException in open", e);
+                if (config.enableDebugLogging) Log.e(TAG, "Encountered IOException in open", e);
             }
         }
         openCount++;
@@ -137,19 +137,25 @@ public class Sift {
         @SerializedName(value="disallow_location_collection", alternate={"disallowLocationCollection"})
         public final boolean disallowLocationCollection;
 
+        /** Whether to allow location collection; defaults to false. */
+        @SerializedName(value="enable_debug_logging", alternate={"enableDebugLogging"})
+        public final boolean enableDebugLogging;
+
         // The default no-args constructor for JSON.
         Config() {
-            this(null, null, DEFAULT_SERVER_URL_FORMAT, false);
+            this(null, null, DEFAULT_SERVER_URL_FORMAT, false, false);
         }
 
         private Config(String accountId,
                        String beaconKey,
                        String serverUrlFormat,
-                       boolean disallowLocationCollection) {
+                       boolean disallowLocationCollection,
+                       boolean enableDebugLogging) {
             this.accountId = accountId;
             this.beaconKey = beaconKey;
             this.serverUrlFormat = serverUrlFormat;
             this.disallowLocationCollection = disallowLocationCollection;
+            this.enableDebugLogging = enableDebugLogging;
         }
 
         @Override
@@ -161,7 +167,8 @@ public class Sift {
             return Utils.equals(accountId, that.accountId) &&
                     Utils.equals(beaconKey, that.beaconKey) &&
                     Utils.equals(serverUrlFormat, that.serverUrlFormat) &&
-                    Utils.equals(disallowLocationCollection, that.disallowLocationCollection);
+                    Utils.equals(disallowLocationCollection, that.disallowLocationCollection) &&
+                    Utils.equals(enableDebugLogging, that.enableDebugLogging);
         }
 
         public static class Builder {
@@ -175,6 +182,7 @@ public class Sift {
                 beaconKey = config.beaconKey;
                 serverUrlFormat = config.serverUrlFormat;
                 disallowLocationCollection = config.disallowLocationCollection;
+                enableDebugLogging = config.enableDebugLogging;
             }
 
             private String accountId;
@@ -201,9 +209,15 @@ public class Sift {
                 return this;
             }
 
+            private boolean enableDebugLogging;
+            public Builder withEnableDebugLogging(boolean enableDebugLogging) {
+                this.enableDebugLogging = enableDebugLogging;
+                return this;
+            }
+
             public Config build() {
                 return new Config(accountId, beaconKey, serverUrlFormat,
-                        disallowLocationCollection);
+                        disallowLocationCollection, enableDebugLogging);
             }
         }
     }
@@ -295,7 +309,7 @@ public class Sift {
         try {
             return Sift.GSON.fromJson(archive, Config.class);
         } catch (JsonParseException e) {
-            Log.e(TAG, "Encountered JsonProcessingException in Config constructor", e);
+            if (config.enableDebugLogging) Log.e(TAG, "Encountered JsonProcessingException in Config constructor", e);
             return new Config();
         }
     }
@@ -313,7 +327,7 @@ public class Sift {
         try {
             return Sift.GSON.fromJson(archive, Config.class);
         } catch (JsonSyntaxException e) {
-            Log.d(TAG, "Encountered exception in Sift config unarchive");
+            if (config.enableDebugLogging) Log.d(TAG, "Encountered exception in Sift config unarchive");
             return c == null ? new Config() : c;
         }
     }
@@ -363,10 +377,10 @@ public class Sift {
         executor.shutdown();
         try {
             if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
-                Log.w(TAG, "Some tasks are not terminated yet before timeout");
+                if (config.enableDebugLogging) Log.w(TAG, "Some tasks are not terminated yet before timeout");
             }
         } catch (InterruptedException e) {
-            Log.e(TAG, "Interrupted when awaiting executor", e);
+            if (config.enableDebugLogging) Log.e(TAG, "Interrupted when awaiting executor", e);
         }
     }
 
@@ -390,7 +404,7 @@ public class Sift {
             }
             editor.apply();
         } catch (JsonParseException e) {
-            Log.e(TAG, "Encountered JsonProcessingException in save", e);
+            if (config.enableDebugLogging) Log.e(TAG, "Encountered JsonProcessingException in save", e);
         }
         this.appStateCollector.disconnectLocationServices();
     }

--- a/sift/src/main/java/siftscience/android/Uploader.java
+++ b/sift/src/main/java/siftscience/android/Uploader.java
@@ -164,14 +164,14 @@ class Uploader {
         try {
             return Sift.GSON.fromJson(archive, Batches.class);
         } catch (JsonSyntaxException e) {
-            Log.d(TAG, "Encountered exception in Batches unarchive");
+            if (configProvider.getConfig().enableDebugLogging) Log.d(TAG, "Encountered exception in Batches unarchive");
             return new Batches();
         }
     }
 
 
     void upload(List<MobileEventJson> events) {
-        Log.d(TAG, String.format("Append batch: size=%d", events.size()));
+        if (configProvider.getConfig().enableDebugLogging) Log.d(TAG, String.format("Append batch: size=%d", events.size()));
         if (!events.isEmpty()) {
             batches.append(events);
         }
@@ -190,7 +190,7 @@ class Uploader {
                     try {
                         state.request = makeRequest();
                     } catch (IOException e) {
-                        Log.e(TAG, "Encountered IOException in makeRequest", e);
+                        if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, "Encountered IOException in makeRequest", e);
                     }
                 }
                 if (state.request == null) {
@@ -208,7 +208,7 @@ class Uploader {
                 }
 
                 try {
-                    Log.d(TAG, "Send HTTP request");
+                    if (configProvider.getConfig().enableDebugLogging) Log.d(TAG, "Send HTTP request");
                     // try-with needs API level 19+ :(
                     Response response = client.newCall(state.request).execute();
                     int code = response.code();
@@ -233,18 +233,18 @@ class Uploader {
                         state.numRejects++;
                     }
 
-                    Log.e(TAG, String.format(
+                    if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, String.format(
                             "HTTP error when uploading batch: status=%d response=%s", code, body));
 
 
                 } catch (IOException e) {
-                    Log.e(TAG, "Network error when uploading batch", e);
+                    if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, "Network error when uploading batch", e);
                 }
 
                 if (state.numRejects >= REJECTION_LIMIT) {
                     // This request has been rejected repeatedly;
                     // reset the state and move on to the next batch
-                    Log.e(TAG, "Drop batch due to repeated rejection");
+                    if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, "Drop batch due to repeated rejection");
                     state.reset();
                     batches.pop();
 
@@ -283,18 +283,18 @@ class Uploader {
 
         Sift.Config config = configProvider.getConfig();
         if (config == null) {
-            Log.d(TAG, "Missing Sift.Config object");
+            if (configProvider.getConfig().enableDebugLogging) Log.d(TAG, "Missing Sift.Config object");
             return null;
         }
 
         if (config.accountId == null ||
                 config.beaconKey == null ||
                 config.serverUrlFormat == null) {
-            Log.w(TAG, "Missing account ID, beacon key, and/or server URL format");
+            if (configProvider.getConfig().enableDebugLogging) Log.w(TAG, "Missing account ID, beacon key, and/or server URL format");
             return null;
         }
 
-        Log.i(TAG, String.format("Create HTTP request for batch: size=%d", events.size()));
+        if (configProvider.getConfig().enableDebugLogging) Log.i(TAG, String.format("Create HTTP request for batch: size=%d", events.size()));
 
         String encodedBeaconKey =  Base64.encodeToString(config.beaconKey.getBytes(US_ASCII),
                 Base64.NO_WRAP);
@@ -326,7 +326,7 @@ class Uploader {
             try {
                 executor.schedule(command, delay, unit);
             } catch (RejectedExecutionException e) {
-                Log.e(TAG, "Dropped scheduled task due to RejectedExecutionException");
+                if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, "Dropped scheduled task due to RejectedExecutionException");
             }
         }
     }
@@ -336,7 +336,7 @@ class Uploader {
             try {
                 executor.submit(command);
             } catch (RejectedExecutionException e) {
-                Log.e(TAG, "Dropped submitted task due to RejectedExecutionException");
+                if (configProvider.getConfig().enableDebugLogging) Log.e(TAG, "Dropped submitted task due to RejectedExecutionException");
             }
         }
     }

--- a/sift/src/test/java/siftscience/android/QueueTest.java
+++ b/sift/src/test/java/siftscience/android/QueueTest.java
@@ -324,7 +324,7 @@ public class QueueTest {
         Queue.UploadRequester uploadRequester = mock(Queue.UploadRequester.class);
 
         String queueState = "{\"config\":{\"accept_same_event_after\":1,\"upload_when_more_than\":2," +
-                "\"upload_when_older_than\":3},\"queue\":[],\"last_event\":{\"time\":1513206382563," +
+                "\"upload_when_older_than\":3,\"enable_debug_logging\":false},\"queue\":[],\"last_event\":{\"time\":1513206382563," +
                 "\"user_id\":\"USER_ID\",\"installation_id\":\"a4c7e6b6cae420e9\"," +
                 "\"android_app_state\":{\"activity_class_name\":\"HelloSift\"," +
                 "\"sdk_version\":\"0.9.7\",\"battery_level\":0.5,\"battery_state\":2," +

--- a/sift/src/test/java/siftscience/android/SiftTest.java
+++ b/sift/src/test/java/siftscience/android/SiftTest.java
@@ -170,6 +170,7 @@ public class SiftTest {
         assertNull(sift.getConfig().beaconKey);
         assertNotNull(sift.getConfig().serverUrlFormat);
         assertFalse(sift.getConfig().disallowLocationCollection);
+        assertFalse(sift.getConfig().enableDebugLogging);
 
         assertNull(sift.getUserId());
 
@@ -200,7 +201,8 @@ public class SiftTest {
                 "\"beaconKey\":\"bar\"," +
                 "\"serverUrlFormat\":\"baz\"," +
                 "\"unknown\":\"property\"," +
-                "\"disallowLocationCollection\":true}";
+                "\"disallowLocationCollection\":true," +
+                "\"enableDebugLogging\":true}";
 
         Sift.Config c = sift.GSON.fromJson(jsonAsString, Sift.Config.class);
 
@@ -210,6 +212,7 @@ public class SiftTest {
                 .withBeaconKey("bar")
                 .withServerUrlFormat("baz")
                 .withDisallowLocationCollection(true)
+                .withEnableDebugLogging(true)
                 .build()
         );
     }
@@ -223,6 +226,7 @@ public class SiftTest {
                 .withBeaconKey("b")
                 .withServerUrlFormat("s")
                 .withDisallowLocationCollection(false)
+                .withEnableDebugLogging(false)
                 .build();
 
         Sift sift = new Sift(
@@ -234,7 +238,8 @@ public class SiftTest {
                 "{\"account_id\":\"a\"," +
                         "\"beacon_key\":\"b\"," +
                         "\"server_url_format\":\"s\"," +
-                        "\"disallow_location_collection\":false}");
+                        "\"disallow_location_collection\":false," +
+                        "\"enable_debug_logging\":false}");
 
         assertEquals(sift.GSON.fromJson(configString, Sift.Config.class), c);
     }
@@ -249,6 +254,7 @@ public class SiftTest {
         String legacyConfig = "{\"accountId\":\"a\"," +
                 "\"beaconKey\":\"b\"," +
                 "\"disallowLocationCollection\":false," +
+                "\"enableDebugLogging\":false," +
                 "\"serverUrlFormat\":\"s\"}";
 
         Sift.Config c = sift.GSON.fromJson(legacyConfig, Sift.Config.class);
@@ -258,6 +264,7 @@ public class SiftTest {
                 .withBeaconKey("b")
                 .withServerUrlFormat("s")
                 .withDisallowLocationCollection(false)
+                .withEnableDebugLogging(false)
                 .build());
     }
 

--- a/sift/src/test/java/siftscience/android/SiftTest.java
+++ b/sift/src/test/java/siftscience/android/SiftTest.java
@@ -212,7 +212,7 @@ public class SiftTest {
                 .withBeaconKey("bar")
                 .withServerUrlFormat("baz")
                 .withDisallowLocationCollection(true)
-                .withEnableDebugLogging(true)
+                .withDebugLoggingEnabled(true)
                 .build()
         );
     }
@@ -226,7 +226,7 @@ public class SiftTest {
                 .withBeaconKey("b")
                 .withServerUrlFormat("s")
                 .withDisallowLocationCollection(false)
-                .withEnableDebugLogging(false)
+                .withDebugLoggingEnabled(false)
                 .build();
 
         Sift sift = new Sift(
@@ -264,7 +264,7 @@ public class SiftTest {
                 .withBeaconKey("b")
                 .withServerUrlFormat("s")
                 .withDisallowLocationCollection(false)
-                .withEnableDebugLogging(false)
+                .withDebugLoggingEnabled(false)
                 .build());
     }
 


### PR DESCRIPTION
https://github.com/SiftScience/sift-android/issues/25

> The Sift SDK is generating quite a lot of logs at the info and debug levels, not just error. While these are good for getting started with an SDK, I really don't want to be logging this information in production apps.

This PR adds an `enableDebugLogging` flag to prevent logging by default. Relevant tests and samples have been updated.