### PR TITLE
(For Janice) Deadlock and batch size fixes

### DIFF
--- a/sift/src/main/java/siftscience/android/Queue.java
+++ b/sift/src/main/java/siftscience/android/Queue.java
@@ -163,7 +163,7 @@ public class Queue {
         this.uploadRequester = uploadRequester;
     }
 
-    synchronized String archive() throws JsonParseException {
+    String archive() throws JsonParseException {
         return Sift.GSON.toJson(state);
     }
 

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -224,7 +224,7 @@ public class Sift {
 
     public static final String APP_STATE_QUEUE_IDENTIFIER = "siftscience.android.app";
     private static final Queue.Config APP_STATE_QUEUE_CONFIG = new Queue.Config.Builder()
-            .withUploadWhenMoreThan(32)
+            .withUploadWhenMoreThan(8)
             .withUploadWhenOlderThan(TimeUnit.MINUTES.toMillis(1))
             .build();
 

--- a/sift/src/main/java/siftscience/android/Uploader.java
+++ b/sift/src/main/java/siftscience/android/Uploader.java
@@ -96,7 +96,7 @@ class Uploader {
             batches = new LinkedList<>();
         }
 
-        synchronized String archive() throws JsonParseException {
+        String archive() throws JsonParseException {
             return Sift.GSON.toJson(this);
         }
 


### PR DESCRIPTION
@janiceblue Queue and Upload `archive()` functions are invoked by the Sift singleton `save()`, but both functions are synchronized on Sift instance state, which causes a deadlock in some scenarios.

This fixes that, and also cuts the androidAppState batch size down to 8 from 32 due to OOM errors trying to GSON serialize the string on old devices.