### PR TITLE
(For David) Handle unbound userId

### DIFF
--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -32,6 +32,8 @@ public final class Sift {
     private static volatile SiftImpl instance;
     private static volatile DevicePropertiesCollector devicePropertiesCollector;
     private static volatile AppStateCollector appStateCollector;
+    private static volatile String unboundUserId;
+    private static volatile boolean hasUnboundUserId = false;
 
 
     //================================================================================
@@ -63,9 +65,11 @@ public final class Sift {
         synchronized (Sift.class) {
             if (instance == null) {
                 Context c = context.getApplicationContext();
-                instance = new SiftImpl(c, config);
+                instance = new SiftImpl(c, config, unboundUserId, hasUnboundUserId);
                 devicePropertiesCollector = new DevicePropertiesCollector(instance, c);
                 appStateCollector = new AppStateCollector(instance, c);
+                unboundUserId = null;
+                hasUnboundUserId = false;
             }
         }
 
@@ -139,12 +143,17 @@ public final class Sift {
     public static void close() {
     }
 
-    public static void setUserId(String userId) {
-        instance.setUserId(userId);
+    public static synchronized void setUserId(String userId) {
+        if (instance != null) {
+            instance.setUserId(userId);
+        } else {
+            unboundUserId = userId;
+            hasUnboundUserId = true;
+        }
     }
 
-    public static void unsetUserId() {
-        instance.setUserId(null);
+    public static synchronized void unsetUserId() {
+        setUserId(null);
     }
 
     //================================================================================

--- a/sift/src/main/java/siftscience/android/SiftImpl.java
+++ b/sift/src/main/java/siftscience/android/SiftImpl.java
@@ -93,8 +93,8 @@ class SiftImpl {
         }
     }
 
-    SiftImpl(Context context, Sift.Config config) {
-        this(context, config, new TaskManager());
+    SiftImpl(Context context, Sift.Config config, String unboundUserId, boolean hasUnboundUserId) {
+        this(context, config, unboundUserId, hasUnboundUserId, new TaskManager());
     }
 
     String archiveConfig() {
@@ -120,13 +120,18 @@ class SiftImpl {
     // Instance API
     //================================================================================
 
-    SiftImpl(Context context, Sift.Config conf, TaskManager taskManager) {
+    SiftImpl(Context context, Sift.Config conf, String unboundUserId, boolean hasUnboundUserId,
+             TaskManager taskManager) {
         this.archives = context.getSharedPreferences(ARCHIVE_NAME, Context.MODE_PRIVATE);
         this.taskManager = taskManager;
         this.config = conf;
+        if (hasUnboundUserId) {
+            this.userId = unboundUserId;
+            Log.d(TAG, String.format("Using unbound User ID: %s", userId));
+        }
         this.queues = new HashMap<>();
         this.uploader = new Uploader(taskManager, configProvider);
-        this.taskManager.submit(new UnarchiveTask());
+        this.taskManager.submit(new UnarchiveTask(hasUnboundUserId));
     }
 
     /**
@@ -256,6 +261,12 @@ class SiftImpl {
      * Restores all of the Sift instance state from disk.
      */
     private class UnarchiveTask implements Runnable {
+        private final boolean hasUnboundUserId;
+
+        public UnarchiveTask(boolean hasUnboundUserId) {
+            this.hasUnboundUserId = hasUnboundUserId;
+        }
+
         @Override
         public void run() {
             String archive;
@@ -265,9 +276,13 @@ class SiftImpl {
             config = unarchiveConfig(archive);
             Log.d(TAG, String.format("Unarchived Sift.Config: %s", archive));
 
-            // Unarchive User ID
-            userId = archives.getString(ArchiveKey.USER_ID.key, null);
-            Log.d(TAG, String.format("Unarchived User ID: %s", userId));
+            // Unarchive User ID if we didn't have an unbound one from the Sift class
+            if (!this.hasUnboundUserId) {
+                userId = archives.getString(ArchiveKey.USER_ID.key, null);
+                Log.d(TAG, String.format("Unarchived User ID: %s", userId));
+            }
+
+
 
             // Unarchive Queues
             for (Map.Entry<String, ?> entry : archives.getAll().entrySet()) {


### PR DESCRIPTION
@ehrmann 

Allows for userId operations on the Sift instance before it's been opened.