### PR TITLE
(For David) Allow setConfig on singleton

### DIFF
--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -32,6 +32,8 @@ public final class Sift {
     private static volatile SiftImpl instance;
     private static volatile DevicePropertiesCollector devicePropertiesCollector;
     private static volatile AppStateCollector appStateCollector;
+    private static volatile Config unboundConfig;
+    private static volatile boolean hasUnboundConfig = false;
     private static volatile String unboundUserId;
     private static volatile boolean hasUnboundUserId = false;
 
@@ -65,9 +67,12 @@ public final class Sift {
         synchronized (Sift.class) {
             if (instance == null) {
                 Context c = context.getApplicationContext();
-                instance = new SiftImpl(c, config, unboundUserId, hasUnboundUserId);
+                instance = new SiftImpl(c, config, unboundConfig, hasUnboundConfig,
+                        unboundUserId, hasUnboundUserId);
                 devicePropertiesCollector = new DevicePropertiesCollector(instance, c);
                 appStateCollector = new AppStateCollector(instance, c);
+                unboundConfig = null;
+                hasUnboundConfig = false;
                 unboundUserId = null;
                 hasUnboundUserId = false;
             }
@@ -141,6 +146,15 @@ public final class Sift {
      * Persists instance state to disk and disconnects location services.
      */
     public static void close() {
+    }
+
+    public static synchronized void setConfig(Config c) {
+        if (instance != null) {
+            instance.setConfig(c);
+        } else {
+            unboundConfig = c;
+            hasUnboundConfig = true;
+        }
     }
 
     public static synchronized void setUserId(String userId) {

--- a/sift/src/test/java/siftscience/android/SiftTest.java
+++ b/sift/src/test/java/siftscience/android/SiftTest.java
@@ -183,7 +183,7 @@ public class SiftTest {
         MemorySharedPreferences preferences = new MemorySharedPreferences();
 
         SiftImpl sift = new SiftImpl(
-                mockContext(preferences), null, "", false, mockTaskManager());
+                mockContext(preferences), null, null, false, null, false, mockTaskManager());
 
         assertNotNull(sift.getConfig());
         // Verify default values
@@ -242,7 +242,7 @@ public class SiftTest {
                 .build();
 
         SiftImpl sift = new SiftImpl(
-                mockContext(preferences), c, "", false, mockTaskManager());
+                mockContext(preferences), c, null, false, null, false, mockTaskManager());
 
         String configString = sift.archiveConfig();
 
@@ -280,8 +280,8 @@ public class SiftTest {
                 new Sift.Config.Builder().withDisallowLocationCollection(true).build());
 
         SiftImpl sift1 =
-                new SiftImpl(mockContext(preferences), null, "", false,
-                        mockTaskManager());
+                new SiftImpl(mockContext(preferences), null, null, false,
+                        null, false, mockTaskManager());
         assertTrue(preferences.fields.isEmpty());
 
         sift1.getQueue(SiftImpl.DEVICE_PROPERTIES_QUEUE_IDENTIFIER)
@@ -299,8 +299,8 @@ public class SiftTest {
 
         // Load saved Sift instance state
         SiftImpl sift2 =
-                new SiftImpl(mockContext(preferences), null, "", false,
-                        mockTaskManager());
+                new SiftImpl(mockContext(preferences), null, null, false,
+                        null, false, mockTaskManager());
         assertEquals(sift1.getConfig(), sift2.getConfig());
         assertNull(sift2.getUserId());
 
@@ -325,8 +325,8 @@ public class SiftTest {
 
         // Load saved Sift instance state again
         SiftImpl sift3 =
-                new SiftImpl(mockContext(preferences), null, "", false,
-                        mockTaskManager());
+                new SiftImpl(mockContext(preferences), null, null, false,
+                       null, false, mockTaskManager());
         assertNotEquals(sift1.getConfig(), sift3.getConfig());
         assertEquals(sift2.getConfig(), sift3.getConfig());
         assertEquals("user-id", sift3.getUserId());
@@ -339,8 +339,8 @@ public class SiftTest {
     public void testUnsetUserId() throws Exception {
         MemorySharedPreferences preferences = new MemorySharedPreferences();
 
-        SiftImpl sift = new SiftImpl(mockContext(preferences), null, "", false,
-                mockTaskManager());
+        SiftImpl sift = new SiftImpl(mockContext(preferences), null, null, false,
+                null, false, mockTaskManager());
 
         sift.setUserId("gary");
 
@@ -407,6 +407,105 @@ public class SiftTest {
         SiftImpl sift = (SiftImpl) field.get(Sift.class);
 
         assertEquals(null, sift.getUserId());
+    }
+
+    @Test
+    public void testOpenOverUnboundConfig() throws NoSuchFieldException, IllegalAccessException,
+            InterruptedException {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("foo").build();
+        Sift.Config c2 = new Sift.Config.Builder().withAccountId("bar").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        Sift.setConfig(c1);
+
+        Sift.open(mockContext(preferences), c2);
+
+        Thread.sleep(100);
+
+        Field field = Sift.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        SiftImpl sift = (SiftImpl) field.get(Sift.class);
+
+        // If there's an opened user id, use opened over archived and unbound
+        assertEquals(c2.accountId, sift.getConfig().accountId);
+    }
+
+    @Test
+    public void testUnboundOverArchivedConfig() throws NoSuchFieldException, IllegalAccessException,
+            InterruptedException {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("foo").build();
+        Sift.Config c2 = new Sift.Config.Builder().withAccountId("bar").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        Sift.setConfig(c2);
+
+        Sift.open(mockContext(preferences));
+
+        Thread.sleep(100);
+
+        Field field = Sift.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        SiftImpl sift = (SiftImpl) field.get(Sift.class);
+
+        // If there's an unbound user id and no opened, use unbound over archived
+        assertEquals(c2.accountId, sift.getConfig().accountId);
+    }
+
+    @Test
+    public void testOpenOverArchivedConfig() throws NoSuchFieldException, IllegalAccessException,
+            InterruptedException {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("foo").build();
+        Sift.Config c2 = new Sift.Config.Builder().withAccountId("bar").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        Sift.open(mockContext(preferences), c2);
+
+        Thread.sleep(100);
+
+        Field field = Sift.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        SiftImpl sift = (SiftImpl) field.get(Sift.class);
+
+        // If there's an opened user id and no unbound, use opened over archived
+        assertEquals(c2.accountId, sift.getConfig().accountId);
+    }
+
+    @Test
+    public void testArchivedConfigFallback() throws NoSuchFieldException, IllegalAccessException,
+            InterruptedException {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("bar").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        Sift.open(mockContext(preferences));
+
+        Thread.sleep(100);
+
+        Field field = Sift.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        SiftImpl sift = (SiftImpl) field.get(Sift.class);
+
+        // If there's no opened or unbound user id, use archived
+        assertEquals(c1.accountId, sift.getConfig().accountId);
     }
 
     private Context mockContext(SharedPreferences preferences) {


### PR DESCRIPTION
@ehrmann Addresses #55 and adds lots of tests – notable change is short-circuiting archive in the cases where we have either an opened or unbound user id. Precedence is as follows: opened > unbound > archived