### PR TITLE
(For David) Pass config down from open

### DIFF
--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -73,6 +73,7 @@ public final class Sift {
             }
         }
 
+        instance.setConfig(config);
         appStateCollector.setActivityName(activityName == null ?
                 context.getClass().getSimpleName() : activityName);
 

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -70,15 +70,14 @@ public final class Sift {
                 appStateCollector = new AppStateCollector(instance, c);
                 unboundUserId = null;
                 hasUnboundUserId = false;
+            } else {
+                if (config != null) {
+                    instance.setConfig(config);
+                }
+                appStateCollector.setActivityName(activityName == null ?
+                        context.getClass().getSimpleName() : activityName);
             }
         }
-
-        if (config != null) {
-            instance.setConfig(config);
-        }
-        appStateCollector.setActivityName(activityName == null ?
-                context.getClass().getSimpleName() : activityName);
-
     }
 
     public static void open(@NonNull Context context, String activityName) {

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -74,10 +74,11 @@ public final class Sift {
                 if (config != null) {
                     instance.setConfig(config);
                 }
-                appStateCollector.setActivityName(activityName == null ?
-                        context.getClass().getSimpleName() : activityName);
             }
         }
+
+        appStateCollector.setActivityName(activityName == null ?
+                context.getClass().getSimpleName() : activityName);
     }
 
     public static void open(@NonNull Context context, String activityName) {

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -73,7 +73,9 @@ public final class Sift {
             }
         }
 
-        instance.setConfig(config);
+        if (config != null) {
+            instance.setConfig(config);
+        }
         appStateCollector.setActivityName(activityName == null ?
                 context.getClass().getSimpleName() : activityName);
 

--- a/sift/src/main/java/siftscience/android/SiftImpl.java
+++ b/sift/src/main/java/siftscience/android/SiftImpl.java
@@ -271,18 +271,18 @@ class SiftImpl {
         public void run() {
             String archive;
 
-            // Unarchive Sift config
-            archive = archives.getString(ArchiveKey.CONFIG.key, null);
-            config = unarchiveConfig(archive);
-            Log.d(TAG, String.format("Unarchived Sift.Config: %s", archive));
+            // Unarchive Sift config if we don't have one
+            if (config == null) {
+                archive = archives.getString(ArchiveKey.CONFIG.key, null);
+                config = unarchiveConfig(archive);
+                Log.d(TAG, String.format("Unarchived Sift.Config: %s", archive));
+            }
 
             // Unarchive User ID if we didn't have an unbound one from the Sift class
             if (!this.hasUnboundUserId) {
                 userId = archives.getString(ArchiveKey.USER_ID.key, null);
                 Log.d(TAG, String.format("Unarchived User ID: %s", userId));
             }
-
-
 
             // Unarchive Queues
             for (Map.Entry<String, ?> entry : archives.getAll().entrySet()) {

--- a/sift/src/test/java/siftscience/android/SiftTest.java
+++ b/sift/src/test/java/siftscience/android/SiftTest.java
@@ -210,6 +210,27 @@ public class SiftTest {
     }
 
     @Test
+    public void testConfigPrecedence() {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("sandbox").build();
+        Sift.Config c2 = new Sift.Config.Builder().withAccountId("prod").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        SiftImpl sift = new SiftImpl(
+                mockContext(preferences), c2, "", false, mockTaskManager());
+
+        assertEquals(c2.accountId, sift.getConfig().accountId);
+
+        sift.setConfig(c1);
+
+        assertEquals(c1.accountId, sift.getConfig().accountId);
+    }
+
+    @Test
     public void testUnarchiveUnknownProperty() throws IOException {
         String jsonAsString =
                 "{\"accountId\":\"foo\"," +

--- a/sift/src/test/java/siftscience/android/SiftTest.java
+++ b/sift/src/test/java/siftscience/android/SiftTest.java
@@ -231,6 +231,22 @@ public class SiftTest {
     }
 
     @Test
+    public void testConfigFallback() {
+        MemorySharedPreferences preferences = new MemorySharedPreferences();
+
+        Sift.Config c1 = new Sift.Config.Builder().withAccountId("sandbox").build();
+
+        MemorySharedPreferences.Editor editor = preferences.edit();
+        editor.putString("config", Sift.GSON.toJson(c1));
+        editor.apply();
+
+        SiftImpl sift = new SiftImpl(
+                mockContext(preferences), null, "", false, mockTaskManager());
+
+        assertEquals(c1.accountId, sift.getConfig().accountId);
+    }
+
+    @Test
     public void testUnarchiveUnknownProperty() throws IOException {
         String jsonAsString =
                 "{\"accountId\":\"foo\"," +


### PR DESCRIPTION
Passes down the config in `open` to the instance. Also makes any non-null `open` config take precedence over the archive. Addresses #55 