### PR TITLE
Fix potential NPE in AppStateCollector.getIpAddresses()

### DIFF
--- a/sift/src/main/java/siftscience/android/AppStateCollector.java
+++ b/sift/src/main/java/siftscience/android/AppStateCollector.java
@@ -169,7 +169,7 @@ public class AppStateCollector implements LocationListener,
         List<String> addresses = new ArrayList<>();
         try {
             for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces();
-                 en.hasMoreElements(); ) {
+                 en != null && en.hasMoreElements(); ) {
                 NetworkInterface intf = en.nextElement();
                 for (Enumeration<InetAddress> enumIpAddr = intf.getInetAddresses();
                      enumIpAddr.hasMoreElements(); ) {


### PR DESCRIPTION
Addresses #67 

According to the [documentation](https://docs.oracle.com/javase/7/docs/api/java/net/NetworkInterface.html#getNetworkInterfaces()) for  `NetworkInterface.html.getNetworkInterfaces()`

> Returns null if no network interfaces could be found on this machine