### PR TITLE
Don't send if empty configuration properties.

### DIFF
--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -4,8 +4,9 @@ package siftscience.android;
 
 import java.util.StringJoiner;
 
-import android.content.Context;
 import androidx.annotation.NonNull;
+import android.content.Context;
+import android.util.Log;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -2,8 +2,6 @@
 
 package siftscience.android;
 
-import java.util.StringJoiner;
-
 import androidx.annotation.NonNull;
 import android.content.Context;
 import android.util.Log;
@@ -15,6 +13,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.StringJoiner;
 
 /**
  * The public API of the Sift client library.
@@ -226,7 +225,7 @@ public final class Sift {
 
             if (!valid) {
                 Log.d(TAG, "The following configuration properties are missing or empty: {}",
-                    configurationErrors);
+                    configurationErrors.toString());
             }
 
             return valid;

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -2,6 +2,8 @@
 
 package siftscience.android;
 
+import java.util.StringJoiner;
+
 import android.content.Context;
 import androidx.annotation.NonNull;
 
@@ -201,6 +203,32 @@ public final class Sift {
             this.beaconKey = beaconKey;
             this.serverUrlFormat = serverUrlFormat;
             this.disallowLocationCollection = disallowLocationCollection;
+        }
+
+        boolean isValid() {
+
+            StringJoiner configurationErrors = new StringJoiner(", ");
+
+            if (accountId == null || accountId.isEmpty()) {
+                configurationErrors.add("accountId");
+            }
+
+            if (beaconKey == null || beaconKey.isEmpty()) {
+                configurationErrors.add("beacon key");
+            }
+
+            if (serverUrlFormat == null || serverUrlFormat.isEmpty()) {
+                configurationErrors.add("server URL format");
+            }
+
+            boolean valid = configurationErrors.length() == 0;
+
+            if (!valid) {
+                Log.d(TAG, "The following configuration properties are missing or empty: {}",
+                    configurationErrors);
+            }
+
+            return valid;
         }
 
         @Override

--- a/sift/src/main/java/siftscience/android/Uploader.java
+++ b/sift/src/main/java/siftscience/android/Uploader.java
@@ -19,6 +19,7 @@ import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -31,19 +32,18 @@ import java.util.zip.GZIPOutputStream;
  */
 public class Uploader {
     private static final String TAG = Uploader.class.getName();
-
-    @VisibleForTesting
-    static final int MAX_RETRIES = 3;
     private static final long BACKOFF_MULTIPLIER = TimeUnit.SECONDS.toSeconds(3);
     private static final long BACKOFF_EXPONENT = 2;
     private static final TimeUnit BACKOFF_UNIT = TimeUnit.SECONDS;
-    private TaskManager taskManager;
-    private ConfigProvider configProvider;
-
-    private static final Charset US_ASCII = Charset.forName("US-ASCII");
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
+    private static final Charset US_ASCII = StandardCharsets.US_ASCII;
+    private static final Charset UTF8 = StandardCharsets.UTF_8;
     private static final int MAX_BYTES = 4096;
+
+    @VisibleForTesting
+    static final int MAX_RETRIES = 3;
+
+    private final TaskManager taskManager;
+    private final ConfigProvider configProvider;
 
     interface ConfigProvider {
         Sift.Config getConfig();
@@ -128,7 +128,8 @@ public class Uploader {
     /** Builds a Request for the specified event batch */
     @Nullable
     private Request makeRequest(List<MobileEventJson> batch) throws IOException {
-        if (batch.isEmpty()) {
+        if (batch == null || batch.isEmpty()) {
+            Log.d(TAG, "Mobile events batch is empty");
             return null;
         }
 
@@ -139,13 +140,8 @@ public class Uploader {
             return null;
         }
 
-        if (config.accountId == null || config.beaconKey == null || config.serverUrlFormat == null) {
-            Log.d(TAG, "Missing account ID, beacon key, and/or server URL format");
-            return null;
-        }
-
-        if (batch.isEmpty()) {
-            Log.d(TAG, "Batch is null or empty");
+        if (!config.isValid()) {
+            Log.d(TAG, "Sift.Config is not valid");
             return null;
         }
 


### PR DESCRIPTION
Currently, when uploading mobile events in `Uploader.java`, the code only checks if the configuration properties are not null. This means (e.g.) an `accountId` with an empty string will pass the checks and send the event to `/v3/accounts//mobile_events`

To clean up the code, this change moves the configuration validation into a method in the `Config` object called `#isValid()` that returns true/false depending on the state of the configuration.