### PR TITLE
Don't send if empty configuration properties

### DIFF
--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -2,6 +2,8 @@
 
 package siftscience.android;
 
+import java.util.StringJoiner;
+
 import android.content.Context;
 import androidx.annotation.NonNull;
 
@@ -9,6 +11,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import sun.rmi.runtime.Log;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -201,6 +204,32 @@ public final class Sift {
             this.beaconKey = beaconKey;
             this.serverUrlFormat = serverUrlFormat;
             this.disallowLocationCollection = disallowLocationCollection;
+        }
+
+        boolean isValid() {
+
+            StringJoiner configurationErrors = new StringJoiner(", ");
+
+            if (accountId == null || accountId.isEmpty()) {
+                configurationErrors.add("accountId");
+            }
+
+            if (beaconKey == null || beaconKey.isEmpty()) {
+                configurationErrors.add("beacon key");
+            }
+
+            if (serverUrlFormat == null || serverUrlFormat.isEmpty()) {
+                configurationErrors.add("server URL format");
+            }
+
+            boolean valid = configurationErrors.length() == 0;
+
+            if (!valid) {
+                Log.d(TAG, "The following configuration properties are missing or empty: {}",
+                    configurationErrors);
+            }
+
+            return valid;
         }
 
         @Override

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -5,13 +5,16 @@ package siftscience.android;
 import java.util.StringJoiner;
 
 import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import sun.rmi.runtime.Log;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -206,6 +209,7 @@ public final class Sift {
             this.disallowLocationCollection = disallowLocationCollection;
         }
 
+        @RequiresApi(api = Build.VERSION_CODES.N)
         boolean isValid() {
 
             StringJoiner configurationErrors = new StringJoiner(", ");
@@ -225,8 +229,8 @@ public final class Sift {
             boolean valid = configurationErrors.length() == 0;
 
             if (!valid) {
-                Log.d(TAG, "The following configuration properties are missing or empty: {}",
-                    configurationErrors);
+                Log.d(TAG, "The following configuration properties are missing or empty: " +
+                        configurationErrors.toString());
             }
 
             return valid;

--- a/sift/src/main/java/siftscience/android/Uploader.java
+++ b/sift/src/main/java/siftscience/android/Uploader.java
@@ -3,10 +3,12 @@
 package siftscience.android;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
+
+import android.os.Build;
 import android.util.Base64;
 import android.util.Log;
-import sun.rmi.runtime.Log;
 
 import com.sift.api.representations.ListRequestJson;
 import com.sift.api.representations.MobileEventJson;
@@ -23,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
@@ -30,6 +33,7 @@ import java.util.zip.GZIPOutputStream;
 /**
  * Stateless utility class for sending MobileEventJson batches to Sift backend
  */
+@RequiresApi(api = Build.VERSION_CODES.KITKAT)
 public class Uploader {
     private static final String TAG = Uploader.class.getName();
     private static final long BACKOFF_MULTIPLIER = TimeUnit.SECONDS.toSeconds(3);
@@ -100,6 +104,7 @@ public class Uploader {
         this.configProvider = configProvider;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     public void upload(List<MobileEventJson> batch) {
         // Kick-off the first upload
         try {
@@ -126,6 +131,7 @@ public class Uploader {
     }
 
     /** Builds a Request for the specified event batch */
+    @RequiresApi(api = Build.VERSION_CODES.N)
     @Nullable
     private Request makeRequest(List<MobileEventJson> batch) throws IOException {
         if (batch == null || batch.isEmpty()) {


### PR DESCRIPTION
Based on @michaelparkin's pr with build issues.

Currently, when uploading mobile events in Uploader.java, the code only checks if the configuration properties are not null. This means (e.g.) an accountId with an empty string will pass the checks and send the event to /v3/accounts//mobile_events

To clean up the code, this change moves the configuration validation into a method in the Config object called #isValid() that returns true/false depending on the state of the configuration.