### PR TITLE
Updated README to swap save() with pause()

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ public class OtherActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        Sift.save();
+        Sift.pause();
     }
     @Override
     protected void onResume() {


### PR DESCRIPTION
This pr updates the https://github.com/SiftScience/sift-android repo's README to show the correct method to run in `onPause()`. Despite it being in the README, it seems that `Sift.save()` is now `Sift.pause()`.

<img width="298" alt="Screen Shot 2021-03-16 at 3 10 15 PM" src="https://user-images.githubusercontent.com/4394910/111386605-b6b5fc00-8669-11eb-8353-41072df74f32.png">

If I hadn't thought about checking https://github.com/SiftScience/sift-android/releases and seeing 👇🏽 , I would have been stuck and/or started a wild goose chase for what the replacement was.

<img width="613" alt="Screen Shot 2021-03-16 at 3 12 19 PM" src="https://user-images.githubusercontent.com/4394910/111386811-0a284a00-866a-11eb-9e7b-c360aed91039.png">
