### PR TITLE
Added submission issuance instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Sift.unsetUserId();
 <a name="submitting_an_issue"></a>
 ## Submitting an issue
 
-If you find issues please create an issue. We ask you provide the following in your submission.  
+If you find problems or issues with the SDK please create an issue. We ask you provide the following in your submission. 
 
 - Context: Explain how you discovered this issue, include steps to reproduce, and code samples.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Integration](#integration)
   - [Application Integration](#application)
   - [Custom Integration](#custom)
-- [Submitting an Issue](#submitting_an_issue)
+- [Submitting an issue](#submitting_an_issue)
 
 <a name="introduction"></a>
 ## Introduction
@@ -194,10 +194,10 @@ Sift.unsetUserId();
 ``` 
 
 <a name="submitting_an_issue"></a>
-## Submitting an Issue
+## Submitting an issue
 
 If you find issues please create an issue. We ask you provide the following in your submission.  
 
-- Context: Explain how you discovered this issue, include steps to reproduce. and code samples.
+- Context: Explain how you discovered this issue, include steps to reproduce, and code samples.
 
 Thanks for your help!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Integration](#integration)
   - [Application Integration](#application)
   - [Custom Integration](#custom)
-- [Submitting a PR or an Issue](#submitting_an_issue)
+- [Submitting an Issue](#submitting_an_issue)
 
 <a name="introduction"></a>
 ## Introduction
@@ -194,10 +194,10 @@ Sift.unsetUserId();
 ``` 
 
 <a name="submitting_an_issue"></a>
-## Submitting a PR or Issue
+## Submitting an Issue
 
-If you find issues or want to improve the SDK please create a issue or PR. We ask you provide the following in your submission.  
+If you find issues please create an issue. We ask you provide the following in your submission.  
 
-- Provide Context: Explain how you discovered this issue and code samples.
+- Context: Explain how you discovered this issue, include steps to reproduce. and code samples.
 
 Thanks for your help!

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Integration](#integration)
   - [Application Integration](#application)
   - [Custom Integration](#custom)
+- [Submitting a PR or an Issue](#submitting_an_issue)
 
 <a name="introduction"></a>
 ## Introduction
@@ -190,4 +191,13 @@ If the user logs out of your application, you should unset the user id:
 
 ```java
 Sift.unsetUserId();
-```
+``` 
+
+<a name="submitting_an_issue"></a>
+## Submitting a PR or Issue
+
+If you find issues or want to improve the SDK please create a issue or PR. We ask you provide the following in your submission.  
+
+- Provide Context: Explain how you discovered this issue and code samples.
+
+Thanks for your help!


### PR DESCRIPTION
Add instructions to submitting issues for the Android SDK. 
We can work on the wording, but this is to get the ball rolling on it. 
We should probably also do this for our other SDKs. Like a blanket message.

We saw this issue arrive with this issue: https://github.com/SiftScience/sift-android/issues/90, that lacked context and details. 