### PR TITLE
[MSUE-144] Upgraded play-service-location to 21.0.1

### DIFF
--- a/sift/build.gradle
+++ b/sift/build.gradle
@@ -55,7 +55,7 @@ android {
 dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
 
-    implementation 'com.google.android.gms:play-services-location:17.1.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.19.0'


### PR DESCRIPTION
### Purpose
Inorder to fix the _**IncompatibleClassChangeError**_.


### Technical Detail
The current code was using play-services-location:17.1.0
After the release of [play-services-location (21.0.0)](https://developers.google.com/android/guides/releases#october_13_2022) FusedLocationProviderClient is now interfaces instead of classes. 
So upgraded to the latest version of **play-services-location** version 21.0.1


### Testing details
* Ran hello-sift app.
* Check the logs to verify the latitude & longitude are collected
![image](https://user-images.githubusercontent.com/16410756/209276971-5ea906ce-4694-4f58-a041-bade06d8f0a6.png)

