### PR TITLE
Allow sending mobile sdk events to multiple SIFT instances

### DIFF
--- a/hello-sift/src/main/java/siftscience/android/hellosift/HelloSift.java
+++ b/hello-sift/src/main/java/siftscience/android/hellosift/HelloSift.java
@@ -6,11 +6,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.view.View;
 import android.widget.Button;
 
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import siftscience.android.AccountKey;
 import siftscience.android.Sift;
 
 public class HelloSift extends AppCompatActivity {
@@ -27,9 +31,13 @@ public class HelloSift extends AppCompatActivity {
         editor.clear();
         editor.apply();
 
+        List<AccountKey> accountKeys = new ArrayList<>();
+        accountKeys.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        accountKeys.add(new AccountKey("ACCOUNT_ID_3", "BEACON_KEY_3"));
         Sift.open(this, new Sift.Config.Builder()
-                .withAccountId("YOUR_ACCOUNT_ID")
-                .withBeaconKey("YOUR_BEACON_KEY")
+                .withAccountId("ACCOUNT_ID_1")
+                .withBeaconKey("BEACON_KEY_1")
+                .withAccountKeys(accountKeys)
                 .build());
 
         Sift.setUserId("USER_ID");

--- a/sift/src/main/java/siftscience/android/AccountKey.java
+++ b/sift/src/main/java/siftscience/android/AccountKey.java
@@ -1,0 +1,34 @@
+package siftscience.android;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+public class AccountKey {
+    @SerializedName(value = "account_id", alternate = {"accountId"})
+    public final String accountId;
+
+    /**
+     * Your beacon key; defaults to null.
+     */
+    @SerializedName(value = "beacon_key", alternate = {"beaconKey"})
+    public final String beaconKey;
+
+    public AccountKey(String accountId, String beaconKey) {
+        this.accountId = accountId;
+        this.beaconKey = beaconKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AccountKey that = (AccountKey) o;
+        return Objects.equals(accountId, that.accountId) && Objects.equals(beaconKey, that.beaconKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, beaconKey);
+    }
+}

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -314,6 +314,7 @@ public final class Sift {
 
             private String accountId;
 
+            @Deprecated
             public Builder withAccountId(String accountId) {
                 this.accountId = accountId;
                 return this;
@@ -321,6 +322,7 @@ public final class Sift {
 
             private String beaconKey;
 
+            @Deprecated
             public Builder withBeaconKey(String beaconKey) {
                 this.beaconKey = beaconKey;
                 return this;

--- a/sift/src/main/java/siftscience/android/Sift.java
+++ b/sift/src/main/java/siftscience/android/Sift.java
@@ -238,6 +238,7 @@ public final class Sift {
         @SerializedName(value="disallow_location_collection", alternate={"disallowLocationCollection"})
         public final boolean disallowLocationCollection;
 
+        // This is needed to add the separate accountId & beaconKey fields into the accountKeys list when deserializing
         private static final JsonDeserializer deserializer = new JsonDeserializer<Config>() {
             @Override
             public Config deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {

--- a/sift/src/main/java/siftscience/android/Utils.java
+++ b/sift/src/main/java/siftscience/android/Utils.java
@@ -4,6 +4,8 @@ package siftscience.android;
 
 import com.sift.api.representations.MobileEventJson;
 
+import java.util.List;
+
 /**
  * Util methods.
  */
@@ -31,5 +33,17 @@ public class Utils {
             return a == b;
         }
         return a.equals(b);
+    }
+
+    public static boolean equals(List<AccountKey> a, List<AccountKey> b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (!equals(a.get(i), b.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/sift/src/main/java/siftscience/android/Utils.java
+++ b/sift/src/main/java/siftscience/android/Utils.java
@@ -39,6 +39,9 @@ public class Utils {
         if (a == null || b == null) {
             return a == b;
         }
+        if (a.size() != b.size()) {
+            return false;
+        }
         for (int i = 0; i < a.size(); i++) {
             if (!equals(a.get(i), b.get(i))) {
                 return false;

--- a/sift/src/test/java/siftscience/android/MultipleUploaderTest.java
+++ b/sift/src/test/java/siftscience/android/MultipleUploaderTest.java
@@ -1,0 +1,210 @@
+package siftscience.android;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import android.util.Base64;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.sift.api.representations.AndroidDevicePropertiesJson;
+import com.sift.api.representations.MobileEventJson;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class MultipleUploaderTest {
+
+    private List<AccountKey> accountKeys;
+
+    private Uploader.ConfigProvider configProvider;
+    private String requestPath;
+    private TaskManager taskManager;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort());
+
+    private final MobileEventJson TEST_EVENT = new MobileEventJson()
+            .withAndroidDeviceProperties(new AndroidDevicePropertiesJson()
+                    .withAndroidId("foo")
+                    .withDeviceManufacturer("bar")
+                    .withDeviceModel("baz")
+            )
+            .withTime(System.currentTimeMillis())
+            .withUserId("gary");
+
+    @Before
+    public void setUp() {
+        String urlFormat = String.format("http://localhost:%d/v3/accounts/%%s/mobile_events",
+                wireMockRule.port());
+
+        requestPath = "/v3/accounts/%s/mobile_events";
+
+        accountKeys = new ArrayList<AccountKey>();
+        accountKeys.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
+        accountKeys.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        final Sift.Config config = new Sift.Config.Builder()
+                .withAccountKeys(accountKeys)
+                .withServerUrlFormat(urlFormat)
+                .build();
+
+        configProvider = new Uploader.ConfigProvider() {
+            @Override
+            public Sift.Config getConfig() {
+                return config;
+            }
+        };
+
+        taskManager = mockTaskManager();
+    }
+
+    @Test
+    public void testUploadNothing() {
+        Uploader bu = new Uploader(taskManager, configProvider);
+        bu.upload(Collections.<MobileEventJson>emptyList());
+        assertThat(WireMock.findUnmatchedRequests(), Matchers.empty());
+    }
+
+    @Test
+    public void testUpload200() throws Exception {
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.stubFor(makeCall(200, accountKeys.get(i)));
+        }
+
+        Uploader bu = new Uploader(taskManager, configProvider);
+        bu.upload(Collections.singletonList(TEST_EVENT));
+
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.verify(1, WireMock.putRequestedFor(WireMock.urlEqualTo(String.format(requestPath, accountKeys.get(i).accountId))));
+        }
+        assertThat(WireMock.findUnmatchedRequests(), Matchers.empty());
+    }
+
+    @Test
+    public void testUpload400() throws Exception {
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.stubFor(makeCall(400, accountKeys.get(i)));
+        }
+
+        Uploader bu = new Uploader(taskManager, configProvider);
+        bu.upload(Collections.singletonList(TEST_EVENT));
+
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.verify(1, WireMock.putRequestedFor(WireMock.urlEqualTo(String.format(requestPath, accountKeys.get(i).accountId))));
+        }
+        assertThat(WireMock.findUnmatchedRequests(), Matchers.empty());
+    }
+
+    @Test
+    public void testUploadOtherErrorExhaustRetries() throws Exception {
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.stubFor(makeCall(429, accountKeys.get(i)));
+        }
+
+        Uploader bu = new Uploader(taskManager, configProvider);
+        bu.upload(Collections.singletonList(TEST_EVENT));
+
+        for (int i = 0; i < accountKeys.size(); i++) {
+            // ((3 - 3) ^ 2) * 3 = 0
+            verify(taskManager, times(2)).schedule(any(Runnable.class), Mockito.eq(0l),
+                    Mockito.eq(TimeUnit.SECONDS));
+
+            // ((3 - 2) ^ 2) * 3 = 3
+            verify(taskManager, times(2)).schedule(any(Runnable.class), Mockito.eq(3l),
+                    Mockito.eq(TimeUnit.SECONDS));
+
+            // ((3 - 1) ^ 2) * 3 = 12
+            verify(taskManager, times(2)).schedule(any(Runnable.class), Mockito.eq(12l),
+                    Mockito.eq(TimeUnit.SECONDS));
+
+            WireMock.verify(3, WireMock.putRequestedFor(WireMock.urlEqualTo(String.format(requestPath, accountKeys.get(i).accountId))));
+        }
+        assertThat(WireMock.findUnmatchedRequests(), Matchers.empty());
+    }
+
+    @Test
+    public void testUploadOtherEventualSuccess() throws Exception {
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.stubFor(makeCall(429, accountKeys.get(i))
+                    .inScenario(accountKeys.get(i).accountId)
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willSetStateTo("failure"));
+        }
+
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.stubFor(makeCall(200, accountKeys.get(i))
+                    .inScenario(accountKeys.get(i).accountId)
+                    .whenScenarioStateIs("failure")
+                    .willSetStateTo("success")
+            );
+        }
+
+        Uploader bu = new Uploader(taskManager, configProvider);
+        bu.upload(Collections.singletonList(TEST_EVENT));
+
+        for (int i = 0; i < accountKeys.size(); i++) {
+            WireMock.verify(2, WireMock.putRequestedFor(WireMock.urlEqualTo(String.format(requestPath, accountKeys.get(i).accountId))));
+        }
+        assertThat(WireMock.findUnmatchedRequests(), Matchers.empty());
+    }
+
+    private TaskManager mockTaskManager() {
+        TaskManager tm = mock(TaskManager.class);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                ((Runnable) args[0]).run();
+                return null;
+            }
+        }).when(tm).submit(any(Runnable.class));
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                ((Runnable) args[0]).run();
+                return null;
+            }
+        }).when(tm).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+        return tm;
+    }
+
+    private MappingBuilder makeCall(int code, AccountKey accountKey) throws Exception {
+        String encodedBeaconKey = Base64.encodeToString(
+                accountKey.beaconKey.getBytes("ASCII"), Base64.NO_WRAP);
+
+        return WireMock.put(WireMock.urlEqualTo(String.format(requestPath, accountKey.accountId)))
+                .withHeader("Accept", WireMock.equalTo("application/json"))
+                .withHeader("Authorization", WireMock.equalTo("Basic " + encodedBeaconKey))
+                .withHeader("Content-Encoding", WireMock.equalTo("gzip"))
+                .withHeader("Content-Type", WireMock.equalTo("application/json"))
+                .willReturn(makeResponse(code));
+    }
+
+    private ResponseDefinitionBuilder makeResponse(int code) {
+        return WireMock.aResponse().withStatus(code);
+    }
+}

--- a/sift/src/test/java/siftscience/android/UtilsTest.java
+++ b/sift/src/test/java/siftscience/android/UtilsTest.java
@@ -1,0 +1,64 @@
+package siftscience.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class UtilsTest {
+
+    @Test
+    public void testListEqualReturnsTrueWhenBothListsAreNull() {
+        List<AccountKey> list1 = null;
+        List<AccountKey> list2 = null;
+        assertTrue(Utils.equals(list1, list2));
+    }
+
+    @Test
+    public void testListEqualReturnsFalseWhenOnlyOneListIsNull() {
+        List<AccountKey> list1 = null;
+        List<AccountKey> list2 = new ArrayList<>();
+        assertFalse(Utils.equals(list1, list2));
+    }
+
+    @Test
+    public void testListEqualReturnsTrueWhenBothListsAreEmpty() {
+        List<AccountKey> list1 = new ArrayList<>();
+        List<AccountKey> list2 = new ArrayList<>();
+        assertTrue(Utils.equals(list1, list2));
+    }
+
+    @Test
+    public void testListEqualReturnsTrueWhenListsAreEqual() {
+        List<AccountKey> list1 = new ArrayList<>();
+        list1.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
+        list1.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        list1.add(new AccountKey("ACCOUNT_ID_3", "BEACON_KEY_3"));
+
+        List<AccountKey> list2 = new ArrayList<>();
+        list2.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
+        list2.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        list2.add(new AccountKey("ACCOUNT_ID_3", "BEACON_KEY_3"));
+        assertTrue(Utils.equals(list1, list2));
+    }
+
+
+    @Test
+    public void testListEqualReturnsFalseWhenListsAreNotEqual() {
+        List<AccountKey> list1 = new ArrayList<>();
+        list1.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
+        list1.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        list1.add(new AccountKey("ACCOUNT_ID_3", "BEACON_KEY_3"));
+
+        List<AccountKey> list2 = new ArrayList<>();
+        list2.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
+        list2.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
+        list2.add(new AccountKey("ACCOUNT_ID_5", "BEACON_KEY_5"));
+        assertFalse(Utils.equals(list1, list2));
+    }
+
+}


### PR DESCRIPTION
### Purpose
Allow sending mobile sdk events to multiple SIFT accounts. Example scenario:

There is a global SIFT account & a regional SIFT account (let's say APAC - Asia Pacific). We want to : 

- send mobile sdk events to global SIFT account for non APAC users 
- send mobile sdk events to both global SIFT & APAC SIFT accounts for APAC users.

At the moment, SIFT sdk only allows sending mobile app events to single SIFT account. This PR will make the SDK flexible to allow sending events to multiple SIFT accounts.

### Technical Detail
The changes are made to support backward compatibility so the existing clients will still be able to use single SIFT account just like before:

```
Sift.open(this, new Sift.Config.Builder()
                .withAccountId("ACCOUNT_ID")
                .withBeaconKey("BEACON_KEY")
                .build());
```

Now we allow initializing the SDK like this as well:

```
List<AccountKey> accountKeys = new ArrayList<>();
accountKeys.add(new AccountKey("ACCOUNT_ID_1", "BEACON_KEY_1"));
accountKeys.add(new AccountKey("ACCOUNT_ID_2", "BEACON_KEY_2"));
Sift.open(this, new Sift.Config.Builder()
                .withAccountKeys(accountKeys)
                .build());
```

### Testing details

- Automated tests
    Added unit tests
- Manual testing
    Ran hello-sift app.
    Check the logs of both SIFT accounts to verify events are being sent to both.
