### PR TITLE
CI-15490  Create Jenkins CI pipeline

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,5 +1,5 @@
 // Load Jenkins shared library
-jenkinsBranch = 'sift-android'
+jenkinsBranch = 'v0.17.0'
 sharedLib = library("shared-lib@${jenkinsBranch}")
 
 def siftAndroidWorkflow = sharedLib.com.sift.ci.SiftAndroidWorkflow.new()

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                 }
             }
         }
-        stage ('Workflow') {
+        stage ('Build') {
             steps {
                 script {
                     ciUtil.updateGithubCommitStatus(repoName, 'Build', 'Started', 'pending', commitSha)

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
     environment {
         GIT_BRANCH = "${env.CHANGE_BRANCH != null? env.CHANGE_BRANCH : env.BRANCH_NAME}"
         ANDROID_SDK_ROOT = "/opt/android/sdk"
+        CACHE_VERSION = 'v1'
     }
     stages {
         stage('Initialize') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,0 +1,89 @@
+// Load Jenkins shared library
+jenkinsBranch = 'sift-android'
+sharedLib = library("shared-lib@${jenkinsBranch}")
+
+def siftandroidWorkflow = sharedLib.com.sift.ci.SiftAndroidWorkflow.new()
+def ciUtil = sharedLib.com.sift.ci.CIUtil.new()
+def stackdriver = sharedLib.com.sift.ci.StackDriverMetrics.new()
+
+// Default GitHub status context for automatically triggered builds
+def defaultStatusContext = 'Jenkins:auto'
+
+// Pod template file for Jenkins agent pod
+// Pod template yaml file is defined in https://github.com/SiftScience/jenkins/tree/master/resources/jenkins-k8s-pod-templates
+def podTemplateFile = 'android-pod-template.yaml'
+def podLabel = "android-${BUILD_TAG}"
+
+
+
+// GitHub repo name
+def repoName = 'sift-android'
+
+pipeline {
+    agent none
+    options {
+        timestamps()
+        skipDefaultCheckout()
+        disableConcurrentBuilds()
+        disableRestartFromStage()
+        parallelsAlwaysFailFast()
+        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')
+    }
+    environment {
+        GIT_BRANCH = "${env.CHANGE_BRANCH != null? env.CHANGE_BRANCH : env.BRANCH_NAME}"
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    statusContext = defaultStatusContext
+                    // Get the commit sha for the build
+                    commitSha = ciUtil.commitHashForBuild()
+                    ciUtil.updateGithubCommitStatus(repoName, statusContext, 'Started', 'pending', commitSha)
+                }
+            }
+        }
+        stage ('Build and Test Workflows') {
+            steps {
+                script {
+                    def workflows = [:]
+                    def stage1 = 'Build'
+                    workflows[stage1] = {
+                        stage(stage1) {
+                            // if (env.GIT_BRANCH.equals('master')) {
+                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'Started', 'pending', commitSha)
+                                try {
+                                    siftAndroidWorkflow.runSiftAndroidBuild(podTemplateFile, podLabel)
+                                    ciUtil.updateGithubCommitStatus(repoName, stage1, 'SUCCESS', 'success', commitSha)
+                                } catch (Exception e) {
+                                    ciUtil.updateGithubCommitStatus(repoName, stage1, 'FAILURE', 'failure', commitSha)
+                                    print("${stage1} failed")
+                                    throw e
+                                }
+                            // }
+                        }
+                    }
+                    parallel workflows
+                }
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                ciUtil.updateGithubCommitStatus(repoName, statusContext, currentBuild.currentResult, 'success', commitSha)
+            }
+        }
+        unsuccessful {
+            script {
+                ciUtil.updateGithubCommitStatus(repoName, statusContext, currentBuild.currentResult, 'failure', commitSha)
+                ciUtil.notifySlack(repoName, commitSha)
+            }
+        }
+        always {
+            script {
+                stackdriver.updatePipelineStatistics(this)
+            }
+        }
+    }
+}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
     }
     environment {
         GIT_BRANCH = "${env.CHANGE_BRANCH != null? env.CHANGE_BRANCH : env.BRANCH_NAME}"
+        ANDROID_SDK_ROOT = "/opt/android/sdk"
     }
     stages {
         stage('Initialize') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -2,7 +2,7 @@
 jenkinsBranch = 'sift-android'
 sharedLib = library("shared-lib@${jenkinsBranch}")
 
-def siftandroidWorkflow = sharedLib.com.sift.ci.SiftAndroidWorkflow.new()
+def siftAndroidWorkflow = sharedLib.com.sift.ci.SiftAndroidWorkflow.new()
 def ciUtil = sharedLib.com.sift.ci.CIUtil.new()
 def stackdriver = sharedLib.com.sift.ci.StackDriverMetrics.new()
 
@@ -28,6 +28,8 @@ pipeline {
         disableRestartFromStage()
         parallelsAlwaysFailFast()
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')
+        timeout(time: 30, unit: 'MINUTES')
+
     }
     environment {
         GIT_BRANCH = "${env.CHANGE_BRANCH != null? env.CHANGE_BRANCH : env.BRANCH_NAME}"
@@ -50,17 +52,15 @@ pipeline {
                     def stage1 = 'Build'
                     workflows[stage1] = {
                         stage(stage1) {
-                            // if (env.GIT_BRANCH.equals('master')) {
-                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'Started', 'pending', commitSha)
-                                try {
-                                    siftAndroidWorkflow.runSiftAndroidBuild(podTemplateFile, podLabel)
-                                    ciUtil.updateGithubCommitStatus(repoName, stage1, 'SUCCESS', 'success', commitSha)
-                                } catch (Exception e) {
-                                    ciUtil.updateGithubCommitStatus(repoName, stage1, 'FAILURE', 'failure', commitSha)
-                                    print("${stage1} failed")
-                                    throw e
-                                }
-                            // }
+                            ciUtil.updateGithubCommitStatus(repoName, stage1, 'Started', 'pending', commitSha)
+                            try {
+                                siftAndroidWorkflow.runSiftAndroidBuild(podTemplateFile, podLabel)
+                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'SUCCESS', 'success', commitSha)
+                            } catch (Exception e) {
+                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'FAILURE', 'failure', commitSha)
+                                print("${stage1} failed")
+                                throw e
+                            }
                         }
                     }
                     parallel workflows

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -14,8 +14,6 @@ def defaultStatusContext = 'Jenkins:auto'
 def podTemplateFile = 'android-pod-template.yaml'
 def podLabel = "android-${BUILD_TAG}"
 
-
-
 // GitHub repo name
 def repoName = 'sift-android'
 
@@ -56,7 +54,6 @@ pipeline {
                         ciUtil.updateGithubCommitStatus(repoName, 'Build', 'SUCCESS', 'success', commitSha)
                     } catch (Exception e) {
                         ciUtil.updateGithubCommitStatus(repoName, 'Build', 'FAILURE', 'failure', commitSha)
-                        print("${stage1} failed")
                         throw e
                     }
                 }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
                 }
             }
         }
-        stage ('Build and Test Workflows') {
+        stage ('Workflow') {
             steps {
                 script {
                     def workflows = [:]

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -31,7 +31,6 @@ pipeline {
     }
     environment {
         GIT_BRANCH = "${env.CHANGE_BRANCH != null? env.CHANGE_BRANCH : env.BRANCH_NAME}"
-        ANDROID_SDK_ROOT = "/opt/android/sdk"
         CACHE_VERSION = 'v1'
     }
     stages {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -50,22 +50,15 @@ pipeline {
         stage ('Workflow') {
             steps {
                 script {
-                    def workflows = [:]
-                    def stage1 = 'Build'
-                    workflows[stage1] = {
-                        stage(stage1) {
-                            ciUtil.updateGithubCommitStatus(repoName, stage1, 'Started', 'pending', commitSha)
-                            try {
-                                siftAndroidWorkflow.runSiftAndroidBuild(podTemplateFile, podLabel)
-                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'SUCCESS', 'success', commitSha)
-                            } catch (Exception e) {
-                                ciUtil.updateGithubCommitStatus(repoName, stage1, 'FAILURE', 'failure', commitSha)
-                                print("${stage1} failed")
-                                throw e
-                            }
-                        }
+                    ciUtil.updateGithubCommitStatus(repoName, 'Build', 'Started', 'pending', commitSha)
+                    try {
+                        siftAndroidWorkflow.runSiftAndroidBuild(podTemplateFile, podLabel)
+                        ciUtil.updateGithubCommitStatus(repoName, 'Build', 'SUCCESS', 'success', commitSha)
+                    } catch (Exception e) {
+                        ciUtil.updateGithubCommitStatus(repoName, 'Build', 'FAILURE', 'failure', commitSha)
+                        print("${stage1} failed")
+                        throw e
                     }
-                    parallel workflows
                 }
             }
         }


### PR DESCRIPTION
## Purpose
- Create jenkins CI pipeline to replace circleCI 
- https://sift.atlassian.net/browse/CI-15490

## Summary
- Create jenkins CI pipeline that includes  `build `
- Grant jenkins SA write permission to this repo and added github jenkins webhook
- Corresponding jenkins PR: https://github.com/SiftScience/jenkins/pull/524
- Note: `build` and `caching` are currently failing disabled, enable it in jenkins after building new docker image and issue fixed https://sift.atlassian.net/browse/CI-15790

## Testing
- See jenkins build status check below 

## Checklist
- [ ] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [ ] The change was tested with real API calls (if applicable)
- [ ] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README

## Deployment
- Will stop building CircleCI once the PR is approved and merged
- Note: will change jenkins branch back to `master` once jenkins PR is merged